### PR TITLE
Add http sink connector

### DIFF
--- a/agent-c4/build.gradle
+++ b/agent-c4/build.gradle
@@ -102,7 +102,7 @@ dockerCompose {
     environment.put 'CASSANDRA_IMAGE', "${dockerRepo}cassandra:${cassandra4Version}-cdc"
     environment.put 'PULSAR_IMAGE', "${dockerRepo}pulsar:${testPulsarImageTag}-csc"
     waitForTcpPorts = false
-    startedServices = ['cassandra','pulsar']
+    startedServices = ['cassandra','pulsar','http-echo','prometheus','grafana']
 
     stress {
         projectName = "test1"
@@ -113,10 +113,6 @@ dockerCompose {
         projectName = "test1"
         startedServices = ['cassandra-stress']
         scale = ['cassandra-stress': 2]
-    }
-    prometheus {
-        projectName = "test1"
-        startedServices = ['prometheus','grafana']
     }
     elasticsearch {
         projectName = "test1"

--- a/connector/src/docker/Dockerfile
+++ b/connector/src/docker/Dockerfile
@@ -1,9 +1,14 @@
 ARG LUNASTREAMING_IMAGE
 ARG LUNASTREAMING_VERSION
-FROM datastax/lunastreaming-all:2.8.0_1.1.40 as lunastreaming-all
 
+# Install pulsar cassandra source connector
 FROM ${LUNASTREAMING_IMAGE}:${LUNASTREAMING_VERSION}
 ARG BUILD_VERSION
 COPY pulsar-cassandra-source-${BUILD_VERSION}.nar /pulsar/connectors/
-COPY --from=lunastreaming-all /pulsar/connectors/pulsar-io-elastic-search-2.8.0.1.1.40.nar /pulsar/connectors
 
+# Install pulsar http sink connector
+USER root
+RUN apt-get clean && apt-get update && apt-get install -y wget
+RUN wget https://archive.apache.org/dist/pulsar/pulsar-3.0.0/connectors/pulsar-io-http-3.0.0.nar -O /tmp/pulsar-io-http-3.0.0.nar
+RUN mv /tmp/pulsar-io-http-3.0.0.nar /pulsar/connectors
+USER 10000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,29 +45,14 @@ services:
       - '6650:6650'
     command: /bin/bash -c "bin/pulsar standalone -nss"
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.2
-    container_name: elasticsearch
+  # For debugging Pulsar HTTP sink connector
+  # docker logs <container-id> --follow
+  http-echo:
+    image: mendhak/http-https-echo
+    container_name: http-echo
     networks: [ "net1" ]
-    environment:
-      - xpack.security.enabled=false
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    cap_add:
-      - IPC_LOCK
-    #volumes:
-    #  - ./elasticsearch-data:/usr/share/elasticsearch/data
     ports:
-      - 9200:9200
-      - 9300:9300
+      - '8088:8080'
 
   prometheus:
     image: prom/prometheus

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@ dse4Version=6.8.23
 pulsarGroup=org.apache.pulsar
 pulsarVersion=3.0.0
 # Used when running tests locally, CI will override those values
-testPulsarImage=datastax/lunastreaming
-testPulsarImageTag=2.10_3.4
+testPulsarImage=apachepulsar/pulsar
+testPulsarImageTag=3.0.0
 
 kafkaVersion=3.4.0
 vavrVersion=0.10.3


### PR DESCRIPTION
# Changes

- Change test pulsar version to 3.0.0 as this is the earliest version that supports http sink connector
- Change pulsar image to [open source version](https://hub.docker.com/r/apachepulsar/pulsar/tags?page=1&name=3.0.0) instead of [luna streaming](https://hub.docker.com/r/datastax/lunastreaming/tags) (production) version as it has versions later than 2.10
- Add http-echo docker image which echos whatever http request gets routed to it for debugging the sink connector
- Install http sink connector in docker image for pulsar

# Testing

```
# Pulls images from yarkhinephyo2019 public registry and sets up Cassandra, Pulsar, Monitoring tools

./gradlew agent-c4:composeUp

# Create Cassandra table

docker exec -it cassandra cqlsh -e "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};"
docker exec -it cassandra cqlsh -e "CREATE TABLE ks1.table1 (a text, b text, PRIMARY KEY (a)) WITH cdc=true;"

# Create Pulsar source topic

docker exec -it pulsar bin/pulsar-admin source create \
--source-type cassandra-source \
--tenant public \
--namespace default \
--name cassandra-source-ks1-table1 \
--destination-topic-name data-ks1.table1 \
--source-config "{
  \"keyspace\": \"ks1\",
  \"table\": \"table1\",
  \"events.topic\": \"persistent://public/default/events-ks1.table1\",
  \"events.subscription.name\": \"sub1\",
  \"contactPoints\": \"cassandra\",
  \"loadBalancing.localDc\": \"datacenter1\"
}"

# Create Pulsar sink topic

docker exec -it pulsar bin/pulsar-admin sink create \
--sink-type http \
--tenant public \
--namespace default \
--name http-sink-ks1-table1-2 \
--inputs data-ks1.table1 \
--sink-config "{
  \"url\": \"http://http-echo:8080/hello-world\"
}"

# In another terminal, monitor the http echo docker instance

docker logs <container-id> --follow

# Add two rows into the Cassandra table, the http echo instance would print out the POST request made by Pulsar

docker exec -it cassandra cassandra-stress user profile=/table1.yaml no-warmup ops\(insert=1\) n=2 -rate threads=10

```

Other note:

```
# Ensuring builds for both ARM and x86
docker buildx create --name mybuilder
docker buildx use mybuilder

# Building and pushing docker images to yarkhinephyo2019 repository
./gradlew clean build -x test
```